### PR TITLE
Local alert history

### DIFF
--- a/python/bot_alert_rate/__init__.py
+++ b/python/bot_alert_rate/__init__.py
@@ -1,1 +1,2 @@
 from .calculate_alert_rate import *
+from .local_alert_history import alert_history

--- a/python/bot_alert_rate/local_alert_history.py
+++ b/python/bot_alert_rate/local_alert_history.py
@@ -1,0 +1,44 @@
+"""Statistics on the bot alert rate."""
+
+import collections
+import functools
+
+# INIT ########################################################################
+
+def init_alert_history(size: int) -> collections.deque:
+    """Creates a FIFO of fixed size N to store the alerts for the latest N transactions."""
+    return collections.deque(size * [()], size)
+
+# UPDATE ######################################################################
+
+def update_alert_history(fifo: collections.deque, alerts: tuple) -> None:
+    """Push the alert ids for the latest block into the history."""
+    fifo.append(alerts)
+
+# PROCESS #####################################################################
+
+def calculate_alert_rate(fifo: collections.deque, alert: str) -> float:
+    """Calculate the alert rate for a given id over the last N transactions."""
+    return min(sum([_t.count(alert) for _t in fifo]) / len(fifo), 1.)
+
+# WRAPPER #####################################################################
+
+def alert_history(size: int) -> callable:
+    """Creates a decorator for handle_transaction to add an alert history."""
+    _history = init_alert_history(size=size)
+
+    def _decorator(func: callable) -> callable:
+        """Actually wraps the handle_transaction and handles the alert history."""
+
+        @functools.wraps(func)
+        def _wrapper(*args, **kwargs):
+            """Main function called on the logs gathered by the Forta network."""
+            _findings = func(*args, **kwargs)
+            update_alert_history(fifo=_history, alerts=tuple(_f.alert_id for _f in _findings))
+            for _f in _findings:
+                _f.metadata['anomaly_score'] = calculate_alert_rate(fifo=_history, alert=_f.alert_id)
+            return _findings
+
+        return _wrapper
+
+    return _decorator

--- a/python/tests/test_local_alert_history.py
+++ b/python/tests/test_local_alert_history.py
@@ -1,0 +1,83 @@
+import math
+import pytest
+import random
+
+from bot_alert_rate.local_alert_history import (
+    init_alert_history,
+    update_alert_history,
+    calculate_alert_rate,
+    alert_history)
+
+# FINDING #####################################################################
+
+class Finding: # minimal port of the finding class
+    def __init__(self, data):
+        self.alert_id = data.get('alert_id', 'id1')
+        self.metadata = data.get('metadata', {})
+
+# FIXTURES ####################################################################
+
+@pytest.fixture
+def fixed_handle_transaction():
+    def handle_transaction():
+        return [Finding({'alert_id': 'id1', 'metadata': {}})]
+    return handle_transaction
+
+@pytest.fixture
+def random_handle_transaction():
+    def handle_transaction():
+        _findings = []
+        if random.uniform(0., 1.) <= 0.5:
+            _findings.append(Finding({'alert_id': 'id1', 'metadata': {}}))
+        if random.uniform(0., 1.) <= 0.1:
+            _findings.append(Finding({'alert_id': 'id2', 'metadata': {}}))
+        return _findings
+    return handle_transaction
+
+@pytest.fixture
+def random_alert_history(random_handle_transaction):
+    _history = init_alert_history(size=1024)
+    for _ in range(1024):
+        update_alert_history(fifo=_history, alerts=tuple(_f.alert_id for _f in random_handle_transaction()))
+    return _history
+
+# BUFFER ######################################################################
+
+def test_history_has_fixed_size(random_alert_history):
+    _before = len(random_alert_history)
+    for _ in range(128):
+        update_alert_history(fifo=random_alert_history, alerts=())
+    _after = len(random_alert_history)
+    assert _before == _after
+
+# CALCULATION #################################################################
+
+def test_alert_rate_is_a_probability(random_alert_history): # between 0. and 1.
+    _rate_1 = calculate_alert_rate(fifo=random_alert_history, alert='id1')
+    _rate_2 = calculate_alert_rate(fifo=random_alert_history, alert='id2')
+    assert 0. <= _rate_1 and _rate_1 <= 1.
+    assert 0. <= _rate_2 and _rate_2 <= 1.
+
+def test_alert_rate_calculation_is_correct(random_alert_history):
+    _rate_1 = calculate_alert_rate(fifo=random_alert_history, alert='id1')
+    _rate_2 = calculate_alert_rate(fifo=random_alert_history, alert='id2')
+    assert math.isclose(_rate_1, 0.5, abs_tol=0.05)
+    assert math.isclose(_rate_2, 0.1, abs_tol=0.05)
+
+# DECORATOR ###################################################################
+
+def test_decorator_adds_anomaly_score_to_handle_transaction_output(fixed_handle_transaction):
+    @alert_history(size=64)
+    def decorated_handle_transaction():
+        return fixed_handle_transaction()
+    _findings_without_decorator = fixed_handle_transaction()
+    _findings_with_decorator = decorated_handle_transaction()
+    assert 'anomaly_score' not in _findings_without_decorator[0].metadata
+    assert 'anomaly_score' in _findings_with_decorator[0].metadata
+
+def test_decorator_alert_rate_calculation_is_correct(fixed_handle_transaction):
+    @alert_history(size=64)
+    def decorated_handle_transaction():
+        return fixed_handle_transaction()
+    _findings = decorated_handle_transaction()
+    assert _findings[0].metadata['anomaly_score'] == 1. / 64.


### PR DESCRIPTION
Hi @mwakaba2 !

So I went ahead and created a variation of `bot-alert-rate` that stores the alert history in memory.
This is meant to get rid of the web queries (Zetta API) and accelerate the calculation as mentioned in #5 .

The history size is configurable: a size of 10k-100k is only a few kb of memory and should be enough for most bots
(see the [caveat section](#caveat)).

What do you think about it?

## Usage

Just wrap the `handle_transaction` like so:

```python
@alert_history(size=10000)
def _handle_transaction(log: TransactionEvent) -> list:
    pass
```

The decorator automatically adds the `anomaly_score` in  the metadata of the `Finding` objects.

## Caveat

For a bot that trigger regularly, a history of 10k-100k transactions should have enough records for the calculation to be reliable.

However, a bot that triggers less than once an hour would require a larger buffer.
In this case, may-be it would be worth managing the history with a local file buffer or a database? 